### PR TITLE
Clarified title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <!-- regenerate: on (set to off if you edit this file) -->
 
-# Guidance for Migration to Composite, Dual-Certificate, or PQ-Only Authentication
+# Guidance for Migration to Composite, Dual-Certificate, or PQ-Only Certificate Authentication
 
-This is the working area for the individual Internet-Draft, "Guidance for Migration to Composite, Dual-Certificate, or PQ-Only Authentication".
+This is the working area for the individual Internet-Draft, "Guidance for Migration to Composite, Dual-Certificate, or PQ-Only Certificate Authentication".
 
 * [Editor's Copy](https://tireddy2.github.io/pqc-cert-guidance/#go.draft-reddy-pquip-pqc-signature-migration.html)
 * [Datatracker Page](https://datatracker.ietf.org/doc/draft-reddy-pquip-pqc-signature-migration)

--- a/draft-reddy-pquip-pqc-signature-migration.md
+++ b/draft-reddy-pquip-pqc-signature-migration.md
@@ -1,5 +1,5 @@
 ---
-title: Guidance for Migration to Composite, Dual, or PQC-Only Authentication
+title: Guidance for Migration to Composite, Dual, or PQC-Only Certificate Authentication
 abbrev: PQC Signature Migration Guidance
 docname: draft-reddy-pquip-pqc-signature-migration-latest
 category: info


### PR DESCRIPTION
Since the document talks only about Certificate based authentication, this should be in the title. There are many other authentication techniques that are out of scope.